### PR TITLE
Use 'mt' xmlns prefix instead of 'local'

### DIFF
--- a/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.Data.DataForm.Toolkit.xaml
+++ b/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.Data.DataForm.Toolkit.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:vsm="clr-namespace:System.Windows;assembly=OpenSilver"
                     xmlns:controls="clr-namespace:System.Windows.Controls;assembly=OpenSilver.Controls.Data.DataForm.Toolkit"
-                    xmlns:local="http://opensilver.net/themes/modern">
+                    xmlns:mt="http://opensilver.net/themes/modern">
 
     <Style x:Key="DataPagerButtonStyle"
            TargetType="Button">
@@ -17,16 +17,16 @@
                 <ControlTemplate TargetType="Button">
                     <Grid>
                         <Grid.Resources>
-                            <local:BrushBuilder x:Key="HoverBrushBuilder"
-                                            BasedOn="{TemplateBinding Background}"
-                                            BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}" />
-                            <local:BrushBuilder x:Key="PressBrushBuilder"
-                                            BasedOn="{TemplateBinding Background}"
-                                            BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:BrushBuilder x:Key="HoverBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}" />
+                            <mt:BrushBuilder x:Key="PressBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledForegroundBrush"
                                              Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />
@@ -169,10 +169,10 @@
                                     </Setter.Value>
                                 </Setter>
                             </Style>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />

--- a/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.Data.xaml
+++ b/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.Data.xaml
@@ -3,7 +3,7 @@
                     xmlns:vsm="clr-namespace:System.Windows;assembly=OpenSilver"
                     xmlns:data="clr-namespace:System.Windows.Controls;assembly=OpenSilver.Controls.Data"
                     xmlns:dataPrimitives="clr-namespace:System.Windows.Controls.Primitives;assembly=OpenSilver.Controls.Data"
-                    xmlns:local="http://opensilver.net/themes/modern">
+                    xmlns:mt="http://opensilver.net/themes/modern">
 
     <Style x:Key="DataPagerButtonStyle"
            TargetType="Button">
@@ -18,16 +18,16 @@
                 <ControlTemplate TargetType="Button">
                     <Grid>
                         <Grid.Resources>
-                            <local:BrushBuilder x:Key="HoverBrushBuilder"
-                                                BasedOn="{TemplateBinding Background}"
-                                                BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
-                            <local:BrushBuilder x:Key="PressBrushBuilder"
-                                                BasedOn="{TemplateBinding Background}"
-                                                BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:BrushBuilder x:Key="HoverBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
+                            <mt:BrushBuilder x:Key="PressBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledForegroundBrush"
                  Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />
@@ -92,16 +92,16 @@
                 <ControlTemplate TargetType="Button">
                     <Grid>
                         <Grid.Resources>
-                            <local:BrushBuilder x:Key="HoverBrushBuilder"
-                                            BasedOn="{TemplateBinding Background}"
-                                            BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
-                            <local:BrushBuilder x:Key="PressBrushBuilder"
-                                            BasedOn="{TemplateBinding Background}"
-                                            BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                 BasedOn="{TemplateBinding Foreground}"
-                                                 TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                 DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:BrushBuilder x:Key="HoverBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
+                            <mt:BrushBuilder x:Key="PressBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledForegroundBrush"
              Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />
@@ -857,9 +857,9 @@
                 <ControlTemplate TargetType="data:DataGridRow">
                     <DataGridFrozenGrid x:Name="Root">
                         <DataGridFrozenGrid.Resources>
-                            <local:BrushBuilder x:Key="HoverBrushBuilder"
-                                                BasedOn="{Binding Background, ElementName=Root}"
-                                                BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
+                            <mt:BrushBuilder x:Key="HoverBrushBuilder"
+                                             BasedOn="{Binding Background, ElementName=Root}"
+                                             BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
                             <Storyboard x:Key="DetailsVisibleTransition">
                                 <DoubleAnimation Storyboard.TargetName="DetailsPresenter"
                                                  Storyboard.TargetProperty="ContentHeight"
@@ -953,12 +953,12 @@
                             <ControlTemplate x:Key="ToggleButtonTemplate" TargetType="ToggleButton">
                                 <Grid Background="Transparent">
                                     <Grid.Resources>
-                                        <local:BrushBuilder x:Key="HoverBrushBuilder"
-                                                            BasedOn="{TemplateBinding Background}"
-                                                            BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
-                                        <local:BrushBuilder x:Key="PressBrushBuilder"
-                                                            BasedOn="{TemplateBinding Background}"
-                                                            BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
+                                        <mt:BrushBuilder x:Key="HoverBrushBuilder"
+                                                         BasedOn="{TemplateBinding Background}"
+                                                         BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
+                                        <mt:BrushBuilder x:Key="PressBrushBuilder"
+                                                         BasedOn="{TemplateBinding Background}"
+                                                         BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
                                     </Grid.Resources>
                                     <VisualStateManager.VisualStateGroups>
                                         <VisualStateGroup x:Name="CommonStates">

--- a/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.DataVisualization.Toolkit.xaml
+++ b/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.DataVisualization.Toolkit.xaml
@@ -2,7 +2,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:modern="clr-namespace:OpenSilver.Themes.Modern"
-    xmlns:local="http://opensilver.net/themes/modern">
+    xmlns:mt="http://opensilver.net/themes/modern">
 
 
     <!--  AreaDataPoint  -->
@@ -263,9 +263,9 @@
                 <ResourceDictionaryCollection>
                     <!-- Blue -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder1"
-                                                  BasedOn="{DynamicResource Theme_ChartSeriesColor1}"
-                                                  Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder1"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor1}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder1}" Path="GradientStops"/>
@@ -283,9 +283,9 @@
                     </ResourceDictionary>
                     <!-- Red -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder2"
-                                                  BasedOn="{DynamicResource Theme_ChartSeriesColor2}"
-                                                  Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder2"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor2}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder2}" Path="GradientStops"/>
@@ -303,9 +303,9 @@
                     </ResourceDictionary>
                     <!-- Light Green -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder3"
-                                                  BasedOn="{DynamicResource Theme_ChartSeriesColor3}"
-                                                  Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder3"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor3}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder3}" Path="GradientStops"/>
@@ -323,9 +323,9 @@
                     </ResourceDictionary>
                     <!-- Yellow -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder4"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor4}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder4"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor4}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder4}" Path="GradientStops"/>
@@ -343,9 +343,9 @@
                     </ResourceDictionary>
                     <!-- Indigo -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder5"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor5}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder5"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor5}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder5}" Path="GradientStops"/>
@@ -363,9 +363,9 @@
                     </ResourceDictionary>
                     <!-- Magenta -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder6"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor6}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder6"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor6}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder6}" Path="GradientStops"/>
@@ -383,9 +383,9 @@
                     </ResourceDictionary>
                     <!-- Dark Green -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder7"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor7}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder7"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor7}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder7}" Path="GradientStops"/>
@@ -403,9 +403,9 @@
                     </ResourceDictionary>
                     <!-- Gray Shade -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder8"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor8}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder8"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor8}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder8}" Path="GradientStops"/>
@@ -423,9 +423,9 @@
                     </ResourceDictionary>
                     <!-- Blue -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder9"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor9}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder9"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor9}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder9}" Path="GradientStops"/>
@@ -443,9 +443,9 @@
                     </ResourceDictionary>
                     <!-- Brown -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder10"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor10}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder10"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor10}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder10}" Path="GradientStops"/>
@@ -463,9 +463,9 @@
                     </ResourceDictionary>
                     <!-- Cyan -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder11"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor11}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder11"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor11}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder11}" Path="GradientStops"/>
@@ -483,9 +483,9 @@
                     </ResourceDictionary>
                     <!-- Special Blue -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder12"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor12}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder12"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor12}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder12}" Path="GradientStops"/>
@@ -503,9 +503,9 @@
                     </ResourceDictionary>
                     <!-- Gray Shade 2 -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder13"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor13}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder13"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor13}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder13}" Path="GradientStops"/>
@@ -523,9 +523,9 @@
                     </ResourceDictionary>
                     <!-- Gray Shade 3 -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder14"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor14}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder14"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor14}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder14}" Path="GradientStops"/>
@@ -543,9 +543,9 @@
                     </ResourceDictionary>
                     <!-- Gray Shade 4 -->
                     <ResourceDictionary>
-                        <local:BrushEffectBuilder x:Key="BrushEffectBuilder15"
-                          BasedOn="{DynamicResource Theme_ChartSeriesColor15}"
-                          Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
+                        <mt:BrushEffectBuilder x:Key="BrushEffectBuilder15"
+                                               BasedOn="{DynamicResource Theme_ChartSeriesColor15}"
+                                               Mode="{DynamicResource Theme_ChartsBrushEffectMode}"/>
                         <LinearGradientBrush x:Key="Background" StartPoint="0.5,0" EndPoint="0.5,1">
                             <LinearGradientBrush.GradientStops>
                                 <Binding Source="{StaticResource BrushEffectBuilder15}" Path="GradientStops"/>

--- a/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.Input.Toolkit.xaml
+++ b/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.Input.Toolkit.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="http://opensilver.net/themes/modern">
+                    xmlns:mt="http://opensilver.net/themes/modern">
 
     <!-- ListTimePickerPopup Style -->
     <Style TargetType="ListTimePickerPopup">
@@ -694,15 +694,15 @@
                 <ControlTemplate TargetType="ButtonSpinner">
                     <Grid x:Name="RootElement">
                         <Grid.Resources>
-                            <local:ColorInterpolator x:Key="DisabledBorderBuilder"
-                                                     BasedOn="{TemplateBinding BorderBrush}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
-                                                     InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}" />
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledBorderBuilder"
+                                                  BasedOn="{TemplateBinding BorderBrush}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}" />
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}" />
 
                             <SolidColorBrush x:Key="DisabledBorderBrush"

--- a/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.Layout.Toolkit.xaml
+++ b/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.Layout.Toolkit.xaml
@@ -3,7 +3,7 @@
                     xmlns:vsm="clr-namespace:System.Windows;assembly=OpenSilver"
                     xmlns:layoutToolkit="clr-namespace:System.Windows.Controls;assembly=OpenSilver.Controls.Layout.Toolkit"
                     xmlns:layoutPrimitivesToolkit="clr-namespace:System.Windows.Controls.Primitives;assembly=OpenSilver.Controls.Layout.Toolkit"
-                    xmlns:local="http://opensilver.net/themes/modern">
+                    xmlns:mt="http://opensilver.net/themes/modern">
 
     <!--Accordion-->
     <Style x:Name="FlatAccordionStyle"
@@ -113,21 +113,21 @@
                     <Grid Margin="{TemplateBinding Padding}"
                           Background="Transparent">
                         <Grid.Resources>
-                            <local:BrushBuilder x:Key="HoverBrushBuilder"
-                                                BasedOn="{DynamicResource Theme_BorderBrush}"
-                                                BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
-                            <local:BrushBuilder x:Key="PressBrushBuilder"
-                                                BasedOn="{DynamicResource Theme_BorderBrush}"
-                                                BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledBackgroundBuilder"
-                                                     BasedOn="{DynamicResource Theme_BorderBrush}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
-                                                     InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:BrushBuilder x:Key="HoverBrushBuilder"
+                                             BasedOn="{DynamicResource Theme_BorderBrush}"
+                                             BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
+                            <mt:BrushBuilder x:Key="PressBrushBuilder"
+                                             BasedOn="{DynamicResource Theme_BorderBrush}"
+                                             BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledBackgroundBuilder"
+                                                  BasedOn="{DynamicResource Theme_BorderBrush}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
 
                             <SolidColorBrush x:Key="DisabledBackgroundBrush"

--- a/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.Toolkit.xaml
+++ b/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.Toolkit.xaml
@@ -2,15 +2,15 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:vsm="clr-namespace:System.Windows;assembly=OpenSilver"
                     xmlns:controlsToolkit="clr-namespace:System.Windows.Controls;assembly=OpenSilver.Controls.Toolkit"
-                    xmlns:local="http://opensilver.net/themes/modern"
+                    xmlns:mt="http://opensilver.net/themes/modern"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--Button template used in several places-->
     <ControlTemplate x:Key="GlobalCircleButtonTemplate" TargetType="Button">
         <Grid>
             <Grid.Resources>
-                <local:BrushBuilder x:Key="PressBrushBuilder"
-                    BasedOn="{TemplateBinding Foreground}"
-                    BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
+                <mt:BrushBuilder x:Key="PressBrushBuilder"
+                                 BasedOn="{TemplateBinding Foreground}"
+                                 BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
             </Grid.Resources>
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="FocusStates">
@@ -58,10 +58,10 @@
     <ControlTemplate x:Key="GlobalHeaderButtonTemplate" TargetType="Button">
         <Grid Cursor="Hand">
             <Grid.Resources>
-                <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                         BasedOn="{TemplateBinding Foreground}"
-                                         TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                         DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                      BasedOn="{TemplateBinding Foreground}"
+                                      TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                      DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                          InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                 <SolidColorBrush x:Key="DisabledBrush"
                                  Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />
@@ -290,10 +290,10 @@
                                              TargetType="ToggleButton">
                                 <Grid Background="Transparent">
                                     <Grid.Resources>
-                                        <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                                 BasedOn="{TemplateBinding Foreground}"
-                                                                 TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                                 DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                        <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                              BasedOn="{TemplateBinding Foreground}"
+                                                              TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                              DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                                         <SolidColorBrush x:Key="DisabledBrush"
                                                          Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />
@@ -417,10 +417,10 @@
                                              TargetType="ToggleButton">
                                 <Grid Background="Transparent" Cursor="Hand">
                                     <Grid.Resources>
-                                        <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                                 BasedOn="{TemplateBinding Foreground}"
-                                                                 TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                                 DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                        <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                              BasedOn="{TemplateBinding Foreground}"
+                                                              TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                              DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                                         <SolidColorBrush x:Key="DisabledBrush"
                                                          Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />
@@ -539,10 +539,10 @@
                                              TargetType="ToggleButton">
                                 <Grid Background="Transparent">
                                     <Grid.Resources>
-                                        <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                                 BasedOn="{TemplateBinding Foreground}"
-                                                                 TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                                 DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                        <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                              BasedOn="{TemplateBinding Foreground}"
+                                                              TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                              DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                                         <SolidColorBrush x:Key="DisabledBrush"
                                                          Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />
@@ -661,10 +661,10 @@
                                              TargetType="ToggleButton">
                                 <Grid Background="Transparent">
                                     <Grid.Resources>
-                                        <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                                 BasedOn="{TemplateBinding Foreground}"
-                                                                 TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                                 DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                        <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                              BasedOn="{TemplateBinding Foreground}"
+                                                              TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                              DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                                         <SolidColorBrush x:Key="DisabledBrush"
                                                          Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />

--- a/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.xaml
+++ b/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.Controls.xaml
@@ -3,7 +3,7 @@
                     xmlns:vsm="clr-namespace:System.Windows;assembly=OpenSilver"
                     xmlns:controls="clr-namespace:System.Windows.Controls;assembly=OpenSilver.Controls"
                     xmlns:controlsPrimitives="clr-namespace:System.Windows.Controls.Primitives;assembly=OpenSilver.Controls"
-                    xmlns:local="http://opensilver.net/themes/modern">
+                    xmlns:mt="http://opensilver.net/themes/modern">
 
     <!-- TextBlock -->
     <Style TargetType="TextBlock">
@@ -14,9 +14,9 @@
     <ControlTemplate x:Key="CircleButtonTemplate" TargetType="Button">
         <Grid>
             <Grid.Resources>
-                <local:BrushBuilder x:Key="PressBrushBuilder"
-                    BasedOn="{TemplateBinding Foreground}"
-                    BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
+                <mt:BrushBuilder x:Key="PressBrushBuilder"
+                                 BasedOn="{TemplateBinding Foreground}"
+                                 BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
             </Grid.Resources>
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="FocusStates">
@@ -78,20 +78,20 @@
                             <SolidColorBrush x:Key="Theme_WatermarkBrush"
                                              Color="{DynamicResource Theme_WatermarkColor}" />
 
-                            <local:ColorInterpolator x:Key="DisabledBorderBuilder"
-                                                     BasedOn="{DynamicResource Theme_BorderBrush}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
-                                                     InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
-                                                     InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledWatermarkForegroundBuilder"
-                                                     BasedOn="{DynamicResource Theme_WatermarkBrush}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledBorderBuilder"
+                                                  BasedOn="{DynamicResource Theme_BorderBrush}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledWatermarkForegroundBuilder"
+                                                  BasedOn="{DynamicResource Theme_WatermarkBrush}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
 
                             <SolidColorBrush x:Key="DisabledBorderBrush"
@@ -302,10 +302,10 @@
                             <SolidColorBrush x:Key="InactiveBrush">#FF777777</SolidColorBrush>
                             <SolidColorBrush x:Key="SelectedBrush"
                                              Color="{DynamicResource Theme_TextOnPrimaryColor}" />
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />
@@ -461,10 +461,10 @@
                         <Border.Resources>
                             <SolidColorBrush x:Key="SelectedBrush"
                                              Color="{DynamicResource Theme_TextOnPrimaryColor}" />
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />
@@ -598,10 +598,10 @@
     <ControlTemplate x:Key="HeaderButtonTemplate" TargetType="Button">
         <Grid Cursor="Hand">
             <Grid.Resources>
-                <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                         BasedOn="{TemplateBinding Foreground}"
-                                         TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                         DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                      BasedOn="{TemplateBinding Foreground}"
+                                      TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                      DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                          InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                 <SolidColorBrush x:Key="DisabledBrush"
                                  Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />
@@ -637,10 +637,10 @@
                 <ControlTemplate TargetType="CalendarItem">
                     <Grid x:Name="Root">
                         <Grid.Resources>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />
@@ -909,15 +909,15 @@
                 <ControlTemplate TargetType="TabItem">
                     <Grid x:Name="Root">
                         <Grid.Resources>
-                            <local:ColorInterpolator x:Key="DisabledBorderBrushBuilder"
-                                                     BasedOn="{TemplateBinding BorderBrush}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
-                                                     InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledBorderBrushBuilder"
+                                                  BasedOn="{TemplateBinding BorderBrush}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
 
                             <SolidColorBrush x:Key="DisabledBorderBrush"

--- a/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.xaml
+++ b/src/OpenSilver.Themes.Modern/OpenSilver.Themes.Modern/Themes/OpenSilver.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:vsm="clr-namespace:System.Windows;assembly=OpenSilver"
                     xmlns:system="clr-namespace:System;assembly=mscorlib"
-                    xmlns:local="clr-namespace:OpenSilver.Themes.Modern">
+                    xmlns:mt="http://opensilver.net/themes/modern">
 
     <!--ValidationTooltipTemplate-->
     <ControlTemplate x:Key="ValidationToolTipTemplate">
@@ -112,16 +112,16 @@
                 <ControlTemplate TargetType="Button">
                     <Grid>
                         <Grid.Resources>
-                            <local:BrushBuilder x:Key="HoverBrushBuilder"
-                                                BasedOn="{TemplateBinding Background}"
-                                                BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
-                            <local:BrushBuilder x:Key="PressBrushBuilder"
-                                                BasedOn="{TemplateBinding Background}"
-                                                BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledBackgroundBuilder"
-                                                BasedOn="{TemplateBinding Background}"
-                                                TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:BrushBuilder x:Key="HoverBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
+                            <mt:BrushBuilder x:Key="PressBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledBackgroundBuilder"
+                                                  BasedOn="{TemplateBinding Background}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                 InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledBackgroundBuilder}, Path=ResultColor}" />
@@ -220,16 +220,16 @@
                 <ControlTemplate TargetType="ToggleButton">
                     <Grid>
                         <Grid.Resources>
-                            <local:BrushBuilder x:Key="HoverBrushBuilder"
-                                                BasedOn="{TemplateBinding Background}"
-                                                BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
-                            <local:BrushBuilder x:Key="PressBrushBuilder"
-                                                BasedOn="{TemplateBinding Background}"
-                                                BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledBackgroundBuilder"
-                                                     BasedOn="{TemplateBinding Background}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:BrushBuilder x:Key="HoverBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
+                            <mt:BrushBuilder x:Key="PressBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledBackgroundBuilder"
+                                                  BasedOn="{TemplateBinding Background}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledBackgroundBuilder}, Path=ResultColor}" />
@@ -347,16 +347,16 @@
                     <Grid Cursor="Hand"
                           TextOptions.TextHintingMode="Fixed">
                         <Grid.Resources>
-                            <local:BrushBuilder x:Key="HoverBrushBuilder"
-                                                BasedOn="{TemplateBinding Background}"
-                                                BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
-                            <local:BrushBuilder x:Key="PressBrushBuilder"
-                                                BasedOn="{TemplateBinding Background}"
-                                                BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledBackgroundBuilder"
-                                                     BasedOn="{TemplateBinding Background}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:BrushBuilder x:Key="HoverBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
+                            <mt:BrushBuilder x:Key="PressBrushBuilder"
+                                             BasedOn="{TemplateBinding Background}"
+                                             BrightnessRatio="{DynamicResource Theme_PressBrightnessRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledBackgroundBuilder"
+                                                  BasedOn="{TemplateBinding Background}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledBackgroundBuilder}, Path=ResultColor}" />
@@ -461,15 +461,15 @@
                 <ControlTemplate TargetType="TextBox">
                     <Grid x:Name="RootElement">
                         <Grid.Resources>
-                            <local:ColorInterpolator x:Key="DisabledBorderBuilder"
-                                                     BasedOn="{TemplateBinding BorderBrush}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
-                                                     InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledBorderBuilder"
+                                                  BasedOn="{TemplateBinding BorderBrush}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             
                             <SolidColorBrush x:Key="DisabledBorderBrush"
@@ -734,10 +734,10 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Grid.Resources>
-                            <local:ColorInterpolator x:Key="DisabledBackgroundBuilder"
-                                                     BasedOn="{TemplateBinding Background}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledBackgroundBuilder"
+                                                  BasedOn="{TemplateBinding Background}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledBackgroundBuilder}, Path=ResultColor}" />
@@ -1045,15 +1045,15 @@
                 <ControlTemplate TargetType="PasswordBox">
                     <Grid x:Name="RootElement">
                         <Grid.Resources>
-                            <local:ColorInterpolator x:Key="DisabledBorderBuilder"
-                                                     BasedOn="{TemplateBinding BorderBrush}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
-                                                     InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledBorderBuilder"
+                                                  BasedOn="{TemplateBinding BorderBrush}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
 
                             <SolidColorBrush x:Key="DisabledBorderBrush"
@@ -1249,10 +1249,10 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Grid.Resources>
-                            <local:ColorInterpolator x:Key="DisabledColorBuilder"
-                                                     BasedOn="{TemplateBinding BorderBrush}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledColorBuilder"
+                                                  BasedOn="{TemplateBinding BorderBrush}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledColorBuilder}, Path=ResultColor}" />
@@ -1490,16 +1490,16 @@
                     <Grid Background="{TemplateBinding Background}"
                           Margin="2,1">
                         <Grid.Resources>
-                            <local:BrushBuilder x:Key="HoverBrushBuilder"
-                                                BasedOn="{Binding Background, ElementName=SelectedBackground}"
-                                                BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
+                            <mt:BrushBuilder x:Key="HoverBrushBuilder"
+                                             BasedOn="{Binding Background, ElementName=SelectedBackground}"
+                                             BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}"/>
                             <SolidColorBrush x:Key="SelectedBrush"
                                              Color="{DynamicResource Theme_TextOnPrimaryColor}" />
 
-                            <local:ColorInterpolator x:Key="DisabledBackgroundBuilder"
-                                                     BasedOn="{Binding Background, ElementName=SelectedBackground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledBackgroundBuilder"
+                                                  BasedOn="{Binding Background, ElementName=SelectedBackground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledBackgroundBuilder}, Path=ResultColor}" />
@@ -2096,10 +2096,10 @@
                 <ControlTemplate TargetType="Thumb">
                     <Grid>
                         <Grid.Resources>
-                            <local:ColorInterpolator x:Key="DisabledBackgroundBuilder"
-                                                     BasedOn="{TemplateBinding BorderBrush}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledBackgroundBuilder"
+                                                  BasedOn="{TemplateBinding BorderBrush}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledBackgroundBuilder}, Path=ResultColor}" />
@@ -2353,13 +2353,13 @@
                         <Grid.Resources>
                             <SolidColorBrush x:Key="SelectedBrush"
                                              Color="{DynamicResource Theme_TextOnPrimaryColor}" />
-                            <local:BrushBuilder x:Key="MouseOverBackgroundBuilder"
-                                                BasedOn="{DynamicResource Theme_PrimaryBrush}"
-                                                BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}" />
-                            <local:ColorInterpolator x:Key="DisabledBackgroundBuilder"
-                                                     BasedOn="{DynamicResource Theme_PrimaryBrush}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:BrushBuilder x:Key="MouseOverBackgroundBuilder"
+                                             BasedOn="{DynamicResource Theme_PrimaryBrush}"
+                                             BrightnessRatio="{DynamicResource Theme_HoverBrightnessRatio}" />
+                            <mt:ColorInterpolator x:Key="DisabledBackgroundBuilder"
+                                                  BasedOn="{DynamicResource Theme_PrimaryBrush}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledBackgroundBuilder}, Path=ResultColor}" />
@@ -2722,7 +2722,7 @@
                 Value="{DynamicResource Theme_ControlBackgroundBrush}" />
         <Setter Property="BorderBrush"
                 Value="{DynamicResource Theme_PrimaryBrush}" />
-        <Setter Property="local:FlatDesignProperties.Label"
+        <Setter Property="mt:FlatDesignProperties.Label"
                 Value=" " />
         <Setter Property="BorderThickness"
                 Value="1" />
@@ -2735,15 +2735,15 @@
                 <ControlTemplate TargetType="ComboBox">
                     <Grid x:Name="Root">
                         <Grid.Resources>
-                            <local:ColorInterpolator x:Key="DisabledBorderBuilder"
-                                                     BasedOn="{DynamicResource Theme_BorderBrush}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
-                                                     InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledBorderBuilder"
+                                                  BasedOn="{DynamicResource Theme_BorderBrush}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                                                  InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             
                             <SolidColorBrush x:Key="DisabledBorderBrush"
@@ -2894,7 +2894,7 @@
                                                   TextBlock.Foreground="{TemplateBinding Foreground}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                   IsHitTestVisible="False">
-                                    <TextBlock Text="{TemplateBinding local:FlatDesignProperties.Label}"
+                                    <TextBlock Text="{TemplateBinding mt:FlatDesignProperties.Label}"
                                                Foreground="{DynamicResource Theme_WatermarkBrush}" />
                                 </ContentPresenter>
                             </Grid>
@@ -3243,10 +3243,10 @@
                           Background="{TemplateBinding Background}"
                           VerticalAlignment="Center">
                         <Grid.Resources>
-                            <local:ColorInterpolator x:Key="DisabledForegroundBuilder"
-                                                     BasedOn="{TemplateBinding Foreground}"
-                                                     TargetColor="{DynamicResource Theme_BackgroundColor}"
-                                                     DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
+                            <mt:ColorInterpolator x:Key="DisabledForegroundBuilder"
+                                                  BasedOn="{TemplateBinding Foreground}"
+                                                  TargetColor="{DynamicResource Theme_BackgroundColor}"
+                                                  DesaturationRatio="{DynamicResource Theme_DisabledDesaturationRatio}"
                                                      InterpolationRatio="{DynamicResource Theme_DisabledInterpolationRatio}"/>
                             <SolidColorBrush x:Key="DisabledBrush"
                                              Color="{Binding Source={StaticResource DisabledForegroundBuilder}, Path=ResultColor}" />


### PR DESCRIPTION
Most likely the end user uses 'mt' prefix for the modern theme, so the copied style can be pasted without any modification